### PR TITLE
Fixes #32. Treat mock file name as literal in matching (#33)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # httptest 3.3.0.9000 (under development)
 * Mocking PUT and POST with a body consisting of only `httr::upload_file` no longer leaves a file connection open. 
+* Mock files with special characters in the filename are now correctly found (#33, @natbprice)
 
 # httptest 3.3.0
 

--- a/R/mock-api.R
+++ b/R/mock-api.R
@@ -164,7 +164,7 @@ find_mock_file <- function (file) {
         }
         ## Turn the basename into a regular expression that will match it (and
         ## only it) with any .extension
-        mockbasename <- paste0("^", basename(mp), ".[[:alnum:]]*$")
+        mockbasename <- paste0("^\\Q", basename(mp), "\\E.[[:alnum:]]*$")
         mockfiles <- dir(dirname(mp), pattern=mockbasename, all.files=TRUE,
             full.names=TRUE)
         ## Remove directories

--- a/tests/testthat/api/x(y='1',z='2').json
+++ b/tests/testthat/api/x(y='1',z='2').json
@@ -1,0 +1,1 @@
+{"object": true}

--- a/tests/testthat/test-mock-api.R
+++ b/tests/testthat/test-mock-api.R
@@ -13,6 +13,10 @@ public({
             expect_json_equivalent(content(obj),
                 list(query=list(a=1), mocked="yes"))
         })
+        test_that("GET with special characters", {
+            a <- GET("api/x(y='1',z='2')")
+            expect_identical(content(a), list(object=TRUE))
+        })
         test_that("GET files that don't exist errors", {
             expect_GET(GET("api/NOTAFILE/"), "api/NOTAFILE/")
             expect_GET(GET("api/NOTAFILE/", query=list(a=1)),


### PR DESCRIPTION
Co-authored-by: Nat Price <nathaniel.price@icf.com>
Co-authored-by: Neal Richardson <neal.p.richardson@gmail.com>